### PR TITLE
fix(#7): Reset CurrentPage when entering filter and calculate TotalPages from FilteredOptions

### DIFF
--- a/src/Extension/Models/PromptState.cs
+++ b/src/Extension/Models/PromptState.cs
@@ -1,9 +1,10 @@
-namespace Extension.Helper;
+namespace Extension.Models;
 
 public class PromptState
 {
     public int PageSize { get; set; }
-    public int TotalPages { get; set; }
+    public int TotalPages =>
+        FilteredOptions.Any() ? (int)Math.Ceiling((double)FilteredOptions.Count / PageSize) : 0;
     public int CurrentPage { get; set; }
     public List<string> FilteredOptions { get; set; }
     public bool IsFilterEnabled { get; set; }
@@ -15,7 +16,6 @@ public class PromptState
     public PromptState(string[] options, int pageSize)
     {
         PageSize = pageSize;
-        TotalPages = (int)Math.Ceiling((double)options.Length / pageSize);
         CurrentPage = 0;
         FilteredOptions = new List<string>(options);
         IsFilterEnabled = false;

--- a/src/Extension/Services/CliPromptService.cs
+++ b/src/Extension/Services/CliPromptService.cs
@@ -1,5 +1,6 @@
 using Extension.Helper;
 using Extension.Interfaces;
+using Extension.Models;
 
 namespace Extension.Services;
 
@@ -80,6 +81,7 @@ public class CliPromptService : ICliPromptService
                 {
                     state.IsFilterEnabled = true;
                     state.FilterValue = string.Empty;
+                    state.CurrentPage = 0;
                 }
             }
         }
@@ -157,6 +159,7 @@ public class CliPromptService : ICliPromptService
                 {
                     state.IsFilterEnabled = true;
                     state.FilterValue = string.Empty;
+                    state.CurrentPage = 0;
                 }
             }
         }


### PR DESCRIPTION
# Description

- Reset `PromptState.CurrentPage` to `0` when entering filter mode
- Calculate `PromptState.TotalPages` based on the `FilteredOptions`
- Move `PromptState` to `Models` folder

Closes #7

## Type of change

Please select relevant options and delete others.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

Please remember that your PR is only valid if all of the below points are checked.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
